### PR TITLE
Remove RunLoop parameter to RunLoop callbacks

### DIFF
--- a/Bindings/Python/Source/RunLoop.c
+++ b/Bindings/Python/Source/RunLoop.c
@@ -132,10 +132,8 @@ struct B_PyRunLoopCallbackClosure_ {
 
 static B_FUNC bool
 b_py_run_loop_function_callback_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
-  (void) rl;
   struct B_PyRunLoopCallbackClosure_ const *closure
     = callback_data;
   bool ok;
@@ -171,11 +169,9 @@ fail:
 
 static B_FUNC bool
 b_py_run_loop_process_callback_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW struct B_ProcessExitStatus const *exit_status,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
-  (void) rl;
   struct B_PyRunLoopCallbackClosure_ const *closure
     = callback_data;
   bool ok;
@@ -218,10 +214,8 @@ fail:
 
 static B_FUNC bool
 b_py_run_loop_cancel_callback_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
-  (void) rl;
   (void) e;
   struct B_PyRunLoopCallbackClosure_ const *closure
     = callback_data;

--- a/Examples/SelfCompile/Source/Main.c
+++ b/Examples/SelfCompile/Source/Main.c
@@ -54,11 +54,9 @@ print_command_(
 
 static B_FUNC bool
 exec_callback_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW struct B_ProcessExitStatus const *status,
     B_BORROW void const *opaque,
     B_OUT struct B_Error *e) {
-  (void) rl;
   struct B_AnswerContext *ac
     = *(struct B_AnswerContext *const *) opaque;
   if (status->type == B_PROCESS_EXIT_STATUS_CODE
@@ -78,10 +76,8 @@ exec_callback_(
 
 static B_FUNC bool
 exec_cancel_callback_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW void const *opaque,
     B_OUT struct B_Error *e) {
-  (void) rl;
   struct B_AnswerContext *ac
     = *(struct B_AnswerContext *const *) opaque;
   if (!b_answer_context_fail(

--- a/Headers/B/RunLoop.h
+++ b/Headers/B/RunLoop.h
@@ -15,13 +15,11 @@ struct B_RunLoopVTable;
 
 typedef B_FUNC bool
 B_RunLoopFunction(
-    B_BORROW struct B_RunLoop *,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *);
 
 typedef B_FUNC bool
 B_RunLoopProcessFunction(
-    B_BORROW struct B_RunLoop *,
     B_BORROW struct B_ProcessExitStatus const *,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *);

--- a/Source/Main.c
+++ b/Source/Main.c
@@ -79,16 +79,13 @@ struct B_MainAnswerCallbackClosure_ {
 
 static B_FUNC bool
 b_main_answer_callback_(
-    B_BORROW struct B_RunLoop *run_loop,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
-  B_PRECONDITION(run_loop);
   B_PRECONDITION(callback_data);
   B_OUT_PARAMETER(e);
 
   struct B_MainAnswerCallbackClosure_ const *closure
     = callback_data;
-  B_ASSERT(run_loop == closure->main->run_loop);
   if (!closure->main->callback(
       closure->main->callback_opaque,
       closure->main,
@@ -101,16 +98,13 @@ b_main_answer_callback_(
 
 static B_FUNC bool
 b_main_answer_cancel_callback_(
-    B_BORROW struct B_RunLoop *run_loop,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
-  B_PRECONDITION(run_loop);
   B_PRECONDITION(callback_data);
   B_OUT_PARAMETER(e);
 
   struct B_MainAnswerCallbackClosure_ const *closure
     = callback_data;
-  B_ASSERT(run_loop == closure->main->run_loop);
   if (!b_answer_context_deallocate(
       closure->answer_context, e)) {
     return false;

--- a/Source/RunLoopKqueue.c
+++ b/Source/RunLoopKqueue.c
@@ -121,28 +121,26 @@ struct B_RunLoopKqueueProcessFallbackClosure_ {
 
 static B_FUNC bool
 b_run_loop_add_process_id_kqueue_fallback_callback_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
   struct B_RunLoopKqueueProcessFallbackClosure_ *closure
     = *(struct B_RunLoopKqueueProcessFallbackClosure_ *
         const *) callback_data;
   bool ok = closure->callback(
-    rl, &closure->exit_status, closure->user_data.bytes, e);
+    &closure->exit_status, closure->user_data.bytes, e);
   b_deallocate(closure);
   return ok;
 }
 
 static B_FUNC bool
 b_run_loop_add_process_id_kqueue_fallback_cancel_(
-    B_BORROW struct B_RunLoop *rl,
     B_BORROW void const *callback_data,
     B_OUT struct B_Error *e) {
   struct B_RunLoopKqueueProcessFallbackClosure_ *closure
     = *(struct B_RunLoopKqueueProcessFallbackClosure_ *
         const *) callback_data;
   bool ok = closure->cancel_callback(
-    rl, closure->user_data.bytes, e);
+    closure->user_data.bytes, e);
   b_deallocate(closure);
   return ok;
 }
@@ -326,7 +324,6 @@ b_run_loop_run_(
             = b_exit_status_from_waitpid_status(
               (int) events[i].data);
           if (!entry->callback(
-              &rl->super,
               &s,
               entry->user_data.bytes,
               &(struct B_Error) {.posix_error = 0})) {

--- a/Source/RunLoopSigchld.c
+++ b/Source/RunLoopSigchld.c
@@ -353,7 +353,6 @@ b_run_loop_check_processes_(
       = b_exit_status_from_waitpid_status(
         entry->u.waitpid_status);
     if (!entry->callback(
-        &rl->super,
         &exit_status,
         entry->user_data.bytes,
         &(struct B_Error) {.posix_error = 0})) {

--- a/Source/RunLoopUtil.c
+++ b/Source/RunLoopUtil.c
@@ -40,7 +40,6 @@ b_run_loop_function_list_deinitialize(
   B_SLIST_FOREACH_SAFE(
       entry, functions, link, temp_entry) {
     if (!entry->cancel_callback(
-        rl,
         entry->user_data.bytes,
         &(struct B_Error) {.posix_error = 0})) {
       B_NYI();
@@ -103,7 +102,6 @@ b_run_loop_function_list_run_one(
   }
   B_SLIST_REMOVE_HEAD(functions, link);
   if (!entry->callback(
-      run_loop,
       entry->user_data.bytes,
       &(struct B_Error) {.posix_error = 0})) {
     B_NYI();


### PR DESCRIPTION
The parameter gets confusing when you forward RunLoops. For
example, when one RunLoop calls another RunLoop's
add_function, you'd expect the callback to receive the
original RunLoop, but it receives the delegate RunLoop
instead.
